### PR TITLE
Create Test Infrastructure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ version '1.0-SNAPSHOT'
 apply plugin: 'java'
 apply plugin: 'com.diffplug.gradle.spotless'
 apply plugin: 'checkstyle'
+apply plugin: 'org.junit.platform.gradle.plugin'
 
 sourceCompatibility = 1.8
 
@@ -26,10 +27,12 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url 'https://plugins.gradle.org/m2/' }
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     }
 
     dependencies {
         classpath group: 'com.diffplug.gradle.spotless', name: 'spotless', version: '2.2.0'
+        classpath group: 'org.junit.platform', name: 'junit-platform-gradle-plugin', version: '1.0.0-SNAPSHOT'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,9 @@ repositories {
 dependencies {
     compile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.0.0-SNAPSHOT'
 
+    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.0.0-SNAPSHOT'
+    testCompile group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.0.0-SNAPSHOT'
+
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.5.2'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.2.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ repositories {
 
 dependencies {
     compile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.0.0-SNAPSHOT'
+
+    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.5.2'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.2.1'
 }
 
 buildscript {

--- a/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
+++ b/src/test/java/org/junit/jupiter/engine/AbstractJupiterTestEngineTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.jupiter.engine;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+
+/**
+ * Abstract base class for tests involving the {@link JupiterTestEngine}.
+ *
+ * @since 5.0
+ */
+public abstract class AbstractJupiterTestEngineTests {
+
+	private final JupiterTestEngine engine = new JupiterTestEngine();
+
+	protected ExecutionEventRecorder executeTestsForClass(Class<?> testClass) {
+		return executeTests(request().selectors(selectClass(testClass)).build());
+	}
+
+	protected ExecutionEventRecorder executeTests(LauncherDiscoveryRequest request) {
+		TestDescriptor testDescriptor = discoverTests(request);
+		ExecutionEventRecorder eventRecorder = new ExecutionEventRecorder();
+		engine.execute(new ExecutionRequest(testDescriptor, eventRecorder, request.getConfigurationParameters()));
+		return eventRecorder;
+	}
+
+	protected TestDescriptor discoverTests(LauncherDiscoveryRequest request) {
+		return engine.discover(request, UniqueId.forEngine(engine.getId()));
+	}
+
+}

--- a/src/test/java/org/junit/platform/engine/test/TestDescriptorStub.java
+++ b/src/test/java/org/junit/platform/engine/test/TestDescriptorStub.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.engine.test;
+
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
+
+/**
+ * @since 1.0
+ */
+public class TestDescriptorStub extends AbstractTestDescriptor {
+
+	public TestDescriptorStub(UniqueId uniqueId, String displayName) {
+		super(uniqueId, displayName);
+	}
+
+	@Override
+	public boolean isTest() {
+		return getChildren().isEmpty();
+	}
+
+	@Override
+	public boolean isContainer() {
+		return !isTest();
+	}
+
+}

--- a/src/test/java/org/junit/platform/engine/test/TestEngineSpy.java
+++ b/src/test/java/org/junit/platform/engine/test/TestEngineSpy.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.engine.test;
+
+import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.engine.UniqueId;
+
+/**
+ * @since 1.0
+ */
+public class TestEngineSpy implements TestEngine {
+
+	private static final String ID = TestEngineSpy.class.getSimpleName();
+
+	public EngineDiscoveryRequest discoveryRequestForDiscovery;
+	public UniqueId uniqueIdForDiscovery;
+	public ExecutionRequest requestForExecution;
+
+	@Override
+	public String getId() {
+		return ID;
+	}
+
+	@Override
+	public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+		this.discoveryRequestForDiscovery = discoveryRequest;
+		this.uniqueIdForDiscovery = uniqueId;
+
+		UniqueId engineUniqueId = UniqueId.forEngine(ID);
+		TestDescriptorStub engineDescriptor = new TestDescriptorStub(engineUniqueId, ID);
+		TestDescriptorStub testDescriptor = new TestDescriptorStub(engineUniqueId.append("test", "test"), "test");
+		engineDescriptor.addChild(testDescriptor);
+		return engineDescriptor;
+	}
+
+	@Override
+	public void execute(ExecutionRequest request) {
+		this.requestForExecution = request;
+	}
+}

--- a/src/test/java/org/junit/platform/engine/test/TestEngineStub.java
+++ b/src/test/java/org/junit/platform/engine/test/TestEngineStub.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.engine.test;
+
+import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.engine.UniqueId;
+
+/**
+ * @since 1.0
+ */
+public class TestEngineStub implements TestEngine {
+
+	private final String id;
+
+	public TestEngineStub() {
+		this(TestEngineStub.class.getSimpleName());
+	}
+
+	public TestEngineStub(String id) {
+		this.id = id;
+	}
+
+	@Override
+	public String getId() {
+		return this.id;
+	}
+
+	@Override
+	public TestDescriptor discover(EngineDiscoveryRequest discoveryRequest, UniqueId uniqueId) {
+		return new TestDescriptorStub(UniqueId.forEngine(getId()), getId());
+	}
+
+	@Override
+	public void execute(ExecutionRequest request) {
+	}
+
+}

--- a/src/test/java/org/junit/platform/engine/test/event/ExecutionEvent.java
+++ b/src/test/java/org/junit/platform/engine/test/event/ExecutionEvent.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.engine.test.event;
+
+import static java.util.function.Predicate.isEqual;
+import static org.junit.platform.commons.util.FunctionUtils.where;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.DYNAMIC_TEST_REGISTERED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.FINISHED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.REPORTING_ENTRY_PUBLISHED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.SKIPPED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.STARTED;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.junit.platform.commons.util.ToStringBuilder;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.reporting.ReportEntry;
+
+/**
+ * Represents an event collected by {@link ExecutionEventRecorder}.
+ *
+ * @since 1.0
+ * @see ExecutionEventConditions
+ */
+public class ExecutionEvent {
+
+	public enum Type {
+		DYNAMIC_TEST_REGISTERED, SKIPPED, STARTED, FINISHED, REPORTING_ENTRY_PUBLISHED
+	}
+
+	public static ExecutionEvent reportingEntryPublished(TestDescriptor testDescriptor, ReportEntry entry) {
+		return new ExecutionEvent(REPORTING_ENTRY_PUBLISHED, testDescriptor, entry);
+	}
+
+	public static ExecutionEvent dynamicTestRegistered(TestDescriptor testDescriptor) {
+		return new ExecutionEvent(DYNAMIC_TEST_REGISTERED, testDescriptor, null);
+	}
+
+	public static ExecutionEvent executionSkipped(TestDescriptor testDescriptor, String reason) {
+		return new ExecutionEvent(SKIPPED, testDescriptor, reason);
+	}
+
+	public static ExecutionEvent executionStarted(TestDescriptor testDescriptor) {
+		return new ExecutionEvent(STARTED, testDescriptor, null);
+	}
+
+	public static ExecutionEvent executionFinished(TestDescriptor testDescriptor, TestExecutionResult result) {
+		return new ExecutionEvent(FINISHED, testDescriptor, result);
+	}
+
+	public static Predicate<ExecutionEvent> byType(ExecutionEvent.Type type) {
+		return where(ExecutionEvent::getType, isEqual(type));
+	}
+
+	public static Predicate<ExecutionEvent> byTestDescriptor(Predicate<? super TestDescriptor> predicate) {
+		return where(ExecutionEvent::getTestDescriptor, predicate);
+	}
+
+	public static <T> Predicate<ExecutionEvent> byPayload(Class<T> payloadClass, Predicate<? super T> predicate) {
+		return event -> event.getPayload(payloadClass).filter(predicate).isPresent();
+	}
+
+	private final ExecutionEvent.Type type;
+	private final TestDescriptor testDescriptor;
+	private final Object payload;
+
+	private ExecutionEvent(ExecutionEvent.Type type, TestDescriptor testDescriptor, Object payload) {
+		this.type = type;
+		this.testDescriptor = testDescriptor;
+		this.payload = payload;
+	}
+
+	public ExecutionEvent.Type getType() {
+		return type;
+	}
+
+	public TestDescriptor getTestDescriptor() {
+		return testDescriptor;
+	}
+
+	public <T> Optional<T> getPayload(Class<T> payloadClass) {
+		return Optional.ofNullable(payload).filter(payloadClass::isInstance).map(payloadClass::cast);
+	}
+
+	@Override
+	public String toString() {
+		// @formatter:off
+		return new ToStringBuilder(this)
+				.append("type", type)
+				.append("testDescriptor", testDescriptor)
+				.append("payload", payload)
+				.toString();
+		// @formatter:on
+	}
+
+}

--- a/src/test/java/org/junit/platform/engine/test/event/ExecutionEventConditions.java
+++ b/src/test/java/org/junit/platform/engine/test/event/ExecutionEventConditions.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.engine.test.event;
+
+import static java.util.function.Predicate.isEqual;
+import static org.assertj.core.api.Assertions.allOf;
+import static org.assertj.core.data.Index.atIndex;
+import static org.junit.platform.commons.util.FunctionUtils.where;
+import static org.junit.platform.engine.TestExecutionResult.Status.ABORTED;
+import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
+import static org.junit.platform.engine.TestExecutionResult.Status.SUCCESSFUL;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.DYNAMIC_TEST_REGISTERED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.FINISHED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.SKIPPED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.STARTED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.byPayload;
+import static org.junit.platform.engine.test.event.ExecutionEvent.byTestDescriptor;
+import static org.junit.platform.engine.test.event.ExecutionEvent.byType;
+import static org.junit.platform.engine.test.event.TestExecutionResultConditions.cause;
+import static org.junit.platform.engine.test.event.TestExecutionResultConditions.status;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestExecutionResult.Status;
+import org.junit.platform.engine.support.descriptor.EngineDescriptor;
+import org.junit.platform.engine.test.event.ExecutionEvent.Type;
+
+/**
+ * Collection of AssertJ conditions for {@link ExecutionEvent}.
+ *
+ * @since 1.0
+ */
+public class ExecutionEventConditions {
+
+	@SafeVarargs
+	public static void assertRecordedExecutionEventsContainsExactly(List<ExecutionEvent> executionEvents,
+			Condition<? super ExecutionEvent>... conditions) {
+		SoftAssertions softly = new SoftAssertions();
+		softly.assertThat(executionEvents).hasSize(conditions.length);
+		for (int i = 0; i < conditions.length; i++) {
+			softly.assertThat(executionEvents).has(conditions[i], atIndex(i));
+		}
+		softly.assertAll();
+	}
+
+	@SafeVarargs
+	@SuppressWarnings("varargs")
+	public static Condition<ExecutionEvent> event(Condition<? super ExecutionEvent>... conditions) {
+		return Assertions.<ExecutionEvent> allOf(conditions);
+	}
+
+	public static Condition<ExecutionEvent> engine() {
+		return new Condition<>(byTestDescriptor(EngineDescriptor.class::isInstance), "is an engine");
+	}
+
+	public static Condition<ExecutionEvent> test(String uniqueIdSubstring) {
+		return allOf(test(), uniqueIdSubstring(uniqueIdSubstring));
+	}
+
+	public static Condition<ExecutionEvent> test(String uniqueIdSubstring, String displayName) {
+		return allOf(test(), uniqueIdSubstring(uniqueIdSubstring), displayName(displayName));
+	}
+
+	public static Condition<ExecutionEvent> test() {
+		return new Condition<>(byTestDescriptor(TestDescriptor::isTest), "is a test");
+	}
+
+	public static Condition<ExecutionEvent> container(Class<?> clazz) {
+		return container(clazz.getName());
+	}
+
+	public static Condition<ExecutionEvent> container(String uniqueIdSubstring) {
+		return allOf(container(), uniqueIdSubstring(uniqueIdSubstring));
+	}
+
+	public static Condition<ExecutionEvent> container() {
+		return new Condition<>(byTestDescriptor(TestDescriptor::isContainer), "is a container");
+	}
+
+	public static Condition<ExecutionEvent> dynamicTestRegistered(String uniqueIdSubstring) {
+		return allOf(type(DYNAMIC_TEST_REGISTERED), uniqueIdSubstring(uniqueIdSubstring));
+	}
+
+	public static Condition<ExecutionEvent> uniqueIdSubstring(String uniqueIdSubstring) {
+		return new Condition<>(
+			byTestDescriptor(where(testDescriptor -> testDescriptor.getUniqueId().toString(),
+				uniqueId -> uniqueId.contains(uniqueIdSubstring))),
+			"descriptor with uniqueId substring \"%s\"", uniqueIdSubstring);
+	}
+
+	public static Condition<ExecutionEvent> displayName(String displayName) {
+		return new Condition<>(byTestDescriptor(where(TestDescriptor::getDisplayName, isEqual(displayName))),
+			"descriptor with display name \"%s\"", displayName);
+	}
+
+	public static Condition<ExecutionEvent> skippedWithReason(String expectedReason) {
+		return allOf(type(SKIPPED), reason(expectedReason));
+	}
+
+	public static Condition<ExecutionEvent> started() {
+		return type(STARTED);
+	}
+
+	public static Condition<ExecutionEvent> abortedWithReason(Condition<? super Throwable> causeCondition) {
+		return finishedWithCause(ABORTED, causeCondition);
+	}
+
+	public static Condition<ExecutionEvent> finishedWithFailure(Condition<? super Throwable> causeCondition) {
+		return finishedWithCause(FAILED, causeCondition);
+	}
+
+	private static Condition<ExecutionEvent> finishedWithCause(Status expectedStatus,
+			Condition<? super Throwable> causeCondition) {
+		return finished(allOf(status(expectedStatus), cause(causeCondition)));
+	}
+
+	public static Condition<ExecutionEvent> finishedWithFailure() {
+		return finished(status(FAILED));
+	}
+
+	public static Condition<ExecutionEvent> finishedSuccessfully() {
+		return finished(status(SUCCESSFUL));
+	}
+
+	public static Condition<ExecutionEvent> finished(Condition<TestExecutionResult> resultCondition) {
+		return allOf(type(FINISHED), result(resultCondition));
+	}
+
+	public static Condition<ExecutionEvent> type(Type expectedType) {
+		return new Condition<>(byType(expectedType), "type is %s", expectedType);
+	}
+
+	public static Condition<ExecutionEvent> result(Condition<TestExecutionResult> condition) {
+		return new Condition<>(byPayload(TestExecutionResult.class, condition::matches), "event with result where %s",
+			condition);
+	}
+
+	public static Condition<ExecutionEvent> reason(String expectedReason) {
+		return new Condition<>(byPayload(String.class, isEqual(expectedReason)), "event with reason '%s'",
+			expectedReason);
+	}
+
+}

--- a/src/test/java/org/junit/platform/engine/test/event/ExecutionEventRecorder.java
+++ b/src/test/java/org/junit/platform/engine/test/event/ExecutionEventRecorder.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.engine.test.event;
+
+import static java.util.function.Predicate.isEqual;
+import static java.util.stream.Collectors.toList;
+import static org.junit.platform.commons.util.FunctionUtils.where;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.DYNAMIC_TEST_REGISTERED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.FINISHED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.REPORTING_ENTRY_PUBLISHED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.SKIPPED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.Type.STARTED;
+import static org.junit.platform.engine.test.event.ExecutionEvent.byPayload;
+import static org.junit.platform.engine.test.event.ExecutionEvent.byTestDescriptor;
+import static org.junit.platform.engine.test.event.ExecutionEvent.byType;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.junit.platform.engine.EngineDiscoveryRequest;
+import org.junit.platform.engine.EngineExecutionListener;
+import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestEngine;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestExecutionResult.Status;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.reporting.ReportEntry;
+import org.junit.platform.engine.test.event.ExecutionEvent.Type;
+
+/**
+ * {@link EngineExecutionListener} that records all events and makes them available to tests.
+ *
+ * @since 1.0
+ * @see ExecutionEvent
+ */
+public class ExecutionEventRecorder implements EngineExecutionListener {
+
+	public static List<ExecutionEvent> execute(TestEngine testEngine, EngineDiscoveryRequest discoveryRequest) {
+		TestDescriptor engineTestDescriptor = testEngine.discover(discoveryRequest,
+			UniqueId.forEngine(testEngine.getId()));
+		ExecutionEventRecorder listener = new ExecutionEventRecorder();
+		testEngine.execute(
+			new ExecutionRequest(engineTestDescriptor, listener, discoveryRequest.getConfigurationParameters()));
+		return listener.getExecutionEvents();
+	}
+
+	public final List<ExecutionEvent> executionEvents = new CopyOnWriteArrayList<>();
+
+	@Override
+	public void dynamicTestRegistered(TestDescriptor testDescriptor) {
+		addEvent(ExecutionEvent.dynamicTestRegistered(testDescriptor));
+	}
+
+	@Override
+	public void executionSkipped(TestDescriptor testDescriptor, String reason) {
+		addEvent(ExecutionEvent.executionSkipped(testDescriptor, reason));
+	}
+
+	@Override
+	public void executionStarted(TestDescriptor testDescriptor) {
+		addEvent(ExecutionEvent.executionStarted(testDescriptor));
+	}
+
+	@Override
+	public void executionFinished(TestDescriptor testDescriptor, TestExecutionResult result) {
+		addEvent(ExecutionEvent.executionFinished(testDescriptor, result));
+	}
+
+	@Override
+	public void reportingEntryPublished(TestDescriptor testDescriptor, ReportEntry entry) {
+		addEvent(ExecutionEvent.reportingEntryPublished(testDescriptor, entry));
+	}
+
+	public List<ExecutionEvent> getExecutionEvents() {
+		return executionEvents;
+	}
+
+	public Stream<ExecutionEvent> eventStream() {
+		return getExecutionEvents().stream();
+	}
+
+	public long getTestSkippedCount() {
+		return testEventsByType(SKIPPED).count();
+	}
+
+	public long getTestStartedCount() {
+		return testEventsByType(STARTED).count();
+	}
+
+	public long getReportingEntryPublishedCount() {
+		return testEventsByType(REPORTING_ENTRY_PUBLISHED).count();
+	}
+
+	public long getDynamicTestRegisteredCount() {
+		return testEventsByType(DYNAMIC_TEST_REGISTERED).count();
+	}
+
+	public long getTestFinishedCount() {
+		return testEventsByType(FINISHED).count();
+	}
+
+	public long getTestSuccessfulCount() {
+		return getTestFinishedCount(Status.SUCCESSFUL);
+	}
+
+	public long getTestAbortedCount() {
+		return getTestFinishedCount(Status.ABORTED);
+	}
+
+	public long getTestFailedCount() {
+		return getTestFinishedCount(Status.FAILED);
+	}
+
+	public long getContainerSkippedCount() {
+		return containerEventsByType(SKIPPED).count();
+	}
+
+	public long getContainerStartedCount() {
+		return containerEventsByType(STARTED).count();
+	}
+
+	public long getContainerFinishedCount() {
+		return containerEventsByType(FINISHED).count();
+	}
+
+	public List<ExecutionEvent> getSkippedTestEvents() {
+		return testEventsByType(Type.SKIPPED).collect(toList());
+	}
+
+	public List<ExecutionEvent> getSuccessfulTestFinishedEvents() {
+		return testFinishedEvents(Status.SUCCESSFUL).collect(toList());
+	}
+
+	public List<ExecutionEvent> getFailedTestFinishedEvents() {
+		return testFinishedEvents(Status.FAILED).collect(toList());
+	}
+
+	private long getTestFinishedCount(Status status) {
+		return testFinishedEvents(status).count();
+	}
+
+	private Stream<ExecutionEvent> testFinishedEvents(Status status) {
+		return testEventsByType(FINISHED).filter(
+			byPayload(TestExecutionResult.class, where(TestExecutionResult::getStatus, isEqual(status))));
+	}
+
+	private Stream<ExecutionEvent> testEventsByType(Type type) {
+		return eventsByTypeAndTestDescriptor(type, TestDescriptor::isTest);
+	}
+
+	private Stream<ExecutionEvent> containerEventsByType(Type type) {
+		return eventsByTypeAndTestDescriptor(type, TestDescriptor::isContainer);
+	}
+
+	private Stream<ExecutionEvent> eventsByTypeAndTestDescriptor(Type type,
+			Predicate<? super TestDescriptor> predicate) {
+		return eventStream().filter(byType(type).and(byTestDescriptor(predicate)));
+	}
+
+	private void addEvent(ExecutionEvent event) {
+		executionEvents.add(event);
+	}
+
+}

--- a/src/test/java/org/junit/platform/engine/test/event/TestExecutionResultConditions.java
+++ b/src/test/java/org/junit/platform/engine/test/event/TestExecutionResultConditions.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.junit.platform.engine.test.event;
+
+import static java.util.function.Predicate.isEqual;
+import static org.junit.platform.commons.util.FunctionUtils.where;
+
+import java.util.function.Predicate;
+
+import org.assertj.core.api.Condition;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestExecutionResult.Status;
+
+/**
+ * Collection of AssertJ conditions for {@link TestExecutionResult}.
+ *
+ * @since 1.0
+ */
+public class TestExecutionResultConditions {
+
+	public static Condition<TestExecutionResult> status(Status expectedStatus) {
+		return new Condition<>(where(TestExecutionResult::getStatus, isEqual(expectedStatus)), "status is %s",
+			expectedStatus);
+	}
+
+	public static Condition<Throwable> message(String expectedMessage) {
+		return new Condition<>(where(Throwable::getMessage, isEqual(expectedMessage)), "message is \"%s\"",
+			expectedMessage);
+	}
+
+	public static Condition<Throwable> message(Predicate<String> predicate) {
+		return new Condition<>(where(Throwable::getMessage, predicate), "message is \"%s\"");
+	}
+
+	public static Condition<Throwable> isA(Class<? extends Throwable> expectedClass) {
+		return new Condition<>(expectedClass::isInstance, "instance of %s", expectedClass.getName());
+	}
+
+	public static Condition<Throwable> suppressed(int index, Condition<Throwable> checked) {
+		return new Condition<>(throwable -> checked.matches(throwable.getSuppressed()[index]),
+			"suppressed at index %d matches %s", index, checked);
+
+	}
+
+	public static Condition<TestExecutionResult> cause(Condition<? super Throwable> condition) {
+		return new Condition<TestExecutionResult>(where(TestExecutionResult::getThrowable, throwable -> {
+			return throwable.isPresent() && condition.matches(throwable.get());
+		}), "cause where %s", condition);
+	}
+
+}


### PR DESCRIPTION
This PR includes AssertJ and Mockito, draws in classes from JUnit 5 so tests can extend `AbstractJupiterTestEngineTests` and finally uses the Gradle plugin to run tests.

Fixes #4.

Regarding `AbstractJupiterTestEngineTests`: Unfortunately, JUnit 5 does currently not release test artifacts, (see junit-team/junit5#572), which means that the classes contained in this commit are only available

1. in source form from the JUnit code base
2. in an artifact if said code base is built

Building JUnit as part of Io would add much complexity and overhead. It would technically be possible to use Git to include a part of JUnit's source tree here (by an amalgam of submodules, sparse checkouts, and symlinks) but that would also add much complexity.

Lacking more ideas, I opted for the simplest approach and just copy-pasted the classes into Io.

---

I hereby agree to the terms of the [Io Contributor License Agreement](../CONTRIBUTING.md#io-contributor-license-agreement).