### PR TITLE
Implement Vintage @Test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ repositories {
 
 dependencies {
     compile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.0.0-SNAPSHOT'
+    compile group: 'org.opentest4j', name: 'opentest4j', version: '1.0.0-M1'
 
     testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.0.0-SNAPSHOT'
     testCompile group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.0.0-SNAPSHOT'

--- a/src/main/java/org/codefx/junit/io/vintage/ExpectedExceptionExtension.java
+++ b/src/main/java/org/codefx/junit/io/vintage/ExpectedExceptionExtension.java
@@ -43,8 +43,8 @@ class ExpectedExceptionExtension implements TestExecutionExceptionHandler, After
 	public void handleTestExecutionException(TestExtensionContext context, Throwable throwable) throws Throwable {
 		//@formatter:off
 		boolean throwableMatchesExpectedException = expectedException(context)
-						.filter(expected -> expected.isInstance(throwable))
-						.isPresent();
+				.filter(expected -> expected.isInstance(throwable))
+				.isPresent();
 		//@formatter:on
 
 		// in the `afterTestExecution` callback we have to pass or fail the test

--- a/src/main/java/org/codefx/junit/io/vintage/ExpectedExceptionExtension.java
+++ b/src/main/java/org/codefx/junit/io/vintage/ExpectedExceptionExtension.java
@@ -22,6 +22,10 @@ import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.junit.jupiter.api.extension.TestExtensionContext;
 import org.opentest4j.AssertionFailedError;
 
+/**
+ * This extension implements the expected exception behavior of {@link Test @Test}, where a test only passes if it throws
+ * an exception of the specified type.
+ */
 class ExpectedExceptionExtension implements TestExecutionExceptionHandler, AfterTestExecutionCallback {
 
 	/*

--- a/src/main/java/org/codefx/junit/io/vintage/ExpectedExceptionExtension.java
+++ b/src/main/java/org/codefx/junit/io/vintage/ExpectedExceptionExtension.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.codefx.junit.io.vintage;
+
+import static java.lang.String.format;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.junit.jupiter.api.extension.TestExtensionContext;
+import org.opentest4j.AssertionFailedError;
+
+class ExpectedExceptionExtension implements TestExecutionExceptionHandler, AfterTestExecutionCallback {
+
+	/*
+	 * This extension implements the exception handler callback to compare the thrown exception
+	 * to what was expected. The after test callback (which is called later) builds on
+	 * the results of that check and fails the test if an exception was expected but not thrown.
+	 */
+
+	static final String EXPECTED_EXCEPTION_WAS_NOT_THROWN = "Expected exception %s was not thrown.";
+
+	private static final Namespace NAMESPACE = Namespace.create("io", "ExpectedException");
+	private static final String KEY = "ExceptionWasThrown";
+
+	@Override
+	public void handleTestExecutionException(TestExtensionContext context, Throwable throwable) throws Throwable {
+		//@formatter:off
+		boolean throwableMatchesExpectedException = expectedException(context)
+						.filter(expected -> expected.isInstance(throwable))
+						.isPresent();
+		//@formatter:on
+
+		// in the `afterTestExecution` callback we have to pass or fail the test
+		// depending on whether the exception was thrown or not;
+		// to do that we need to register whether the exception was thrown;
+		// (NOTE that if no exception was thrown, NOTHING is registered)
+		if (throwableMatchesExpectedException) {
+			storeExceptionStatus(context, EXCEPTION.WAS_THROWN_AS_EXPECTED);
+		}
+		else {
+			// this extension is not in charge of the throwable, so we need to rethrow;
+			storeExceptionStatus(context, EXCEPTION.WAS_THROWN_NOT_AS_EXPECTED);
+			throw throwable;
+		}
+	}
+
+	@Override
+	public void afterTestExecution(TestExtensionContext context) throws Exception {
+		switch (loadExceptionStatus(context)) {
+			case WAS_NOT_THROWN:
+				//@formatter:off
+				expectedException(context)
+						.map(expected -> new AssertionFailedError(format(EXPECTED_EXCEPTION_WAS_NOT_THROWN, expected)))
+						.ifPresent(error -> { throw error; });
+				//@formatter:on
+			case WAS_THROWN_AS_EXPECTED:
+				// the exception was thrown as expected so there is nothing to do
+				break;
+			case WAS_THROWN_NOT_AS_EXPECTED:
+				// an exception was thrown but of the wrong type;
+				// it was rethrown in `handleTestExecutionException`
+				// so there is nothing to do here
+				break;
+		}
+	}
+
+	private static Optional<? extends Class<? extends Throwable>> expectedException(ExtensionContext context) {
+		//@formatter:off
+		return findAnnotation(context.getElement(), Test.class)
+				.map(Test::expected)
+				.filter(exceptionType -> exceptionType != Test.None.class);
+		//@formatter:on
+	}
+
+	private static void storeExceptionStatus(ExtensionContext context, EXCEPTION thrown) {
+		context.getStore(NAMESPACE).put(KEY, thrown);
+	}
+
+	private static EXCEPTION loadExceptionStatus(ExtensionContext context) {
+		EXCEPTION thrown = context.getStore(NAMESPACE).get(KEY, EXCEPTION.class);
+		if (thrown == null) {
+			return EXCEPTION.WAS_NOT_THROWN;
+		}
+		else {
+			return thrown;
+		}
+	}
+
+	private enum EXCEPTION {
+		WAS_NOT_THROWN, WAS_THROWN_AS_EXPECTED, WAS_THROWN_NOT_AS_EXPECTED,
+	}
+
+}

--- a/src/main/java/org/codefx/junit/io/vintage/Test.java
+++ b/src/main/java/org/codefx/junit/io/vintage/Test.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(ExpectedExceptionExtension.class)
+@ExtendWith(TimeoutExtension.class)
 @org.junit.jupiter.api.Test
 public @interface Test {
 
@@ -36,5 +37,17 @@ public @interface Test {
 	 * and only if an exception of the specified class is thrown by the method.
 	 */
 	Class<? extends Throwable> expected() default None.class;
+
+	/**
+	 * Optionally specify <code>timeout</code> in milliseconds to cause a test method to fail if it
+	 * takes longer than that number of milliseconds.
+	 * <p>
+	 * <b>NOTE:</b> Unlike the same parameter on JUnit 4's {@code @Test} annotation, this one
+	 * <b>does not</b> lead to a long running test being abandoned.
+	 * Tests will always be allowed to finish (if they do that at all) and their run time might lead
+	 * to the test being failed retroactively.
+	 * </p>
+	 */
+	long timeout() default 0L;
 
 }

--- a/src/main/java/org/codefx/junit/io/vintage/Test.java
+++ b/src/main/java/org/codefx/junit/io/vintage/Test.java
@@ -17,6 +17,11 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 
+/**
+ * {@code @Test} is used to signal that the annotated method is a <em>test</em> method.
+ *
+ * <p>See {@link org.junit.jupiter.api.Test the official @Test} for more information.
+ */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(ExpectedExceptionExtension.class)

--- a/src/main/java/org/codefx/junit/io/vintage/Test.java
+++ b/src/main/java/org/codefx/junit/io/vintage/Test.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.codefx.junit.io.vintage;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@org.junit.jupiter.api.Test
+public @interface Test {
+
+}

--- a/src/main/java/org/codefx/junit/io/vintage/Test.java
+++ b/src/main/java/org/codefx/junit/io/vintage/Test.java
@@ -18,9 +18,14 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * {@code @Test} is used to signal that the annotated method is a <em>test</em> method.
+ * {@code @Test} is used to signal to JUnit Jupiter that the annotated method is a <em>test</em> method - it is designed
+ * to be a drop-in replacement for JUnit 4's {@code @Test}.
  *
- * <p>See {@link org.junit.jupiter.api.Test the official @Test} for more information.
+ * <p>Like JUnit 4's annotation it offers the possibility to {@link #expected() expect exceptions} and to
+ * {@link #timeout() time out} long running tests. The latter functions slightly different from the original - see the
+ * attached Javadoc.
+ *
+ * <p>See {@link org.junit.jupiter.api.Test the official @Test} for more information regarding JUnit Jupiter integration.
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/codefx/junit/io/vintage/Test.java
+++ b/src/main/java/org/codefx/junit/io/vintage/Test.java
@@ -15,9 +15,26 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.junit.jupiter.api.extension.ExtendWith;
+
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(ExpectedExceptionExtension.class)
 @org.junit.jupiter.api.Test
 public @interface Test {
+
+	class None extends Throwable {
+
+		private static final long serialVersionUID = 1L;
+
+		private None() {
+		}
+	}
+
+	/**
+	 * Optionally specify <code>expected</code>, a Throwable, to cause a test method to succeed if
+	 * and only if an exception of the specified class is thrown by the method.
+	 */
+	Class<? extends Throwable> expected() default None.class;
 
 }

--- a/src/main/java/org/codefx/junit/io/vintage/TimeoutExtension.java
+++ b/src/main/java/org/codefx/junit/io/vintage/TimeoutExtension.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.codefx.junit.io.vintage;
+
+import static java.lang.String.format;
+import static java.lang.System.currentTimeMillis;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.TestExtensionContext;
+
+class TimeoutExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
+
+	static final String TEST_RAN_TOO_LONG = "Test '%s' was supposed to run no longer than %d ms but ran %d ms.";
+
+	private static final Namespace NAMESPACE = Namespace.create("io", "Timeout");
+	private static final String LAUNCH_TIME_KEY = "LaunchTime";
+
+	@Override
+	public void beforeTestExecution(TestExtensionContext context) {
+		storeNowAsLaunchTime(context);
+	}
+
+	@Override
+	public void afterTestExecution(TestExtensionContext context) {
+		annotatedTimeout(context).ifPresent(timeout -> failTestIfRanTooLong(context, timeout));
+	}
+
+	private void failTestIfRanTooLong(TestExtensionContext context, Long timeout) {
+		long launchTime = loadLaunchTime(context);
+		long elapsedTime = currentTimeMillis() - launchTime;
+
+		if (elapsedTime > timeout) {
+			String message = format(TEST_RAN_TOO_LONG, context.getDisplayName(), timeout, elapsedTime);
+			throw new AssertionError(message);
+		}
+	}
+
+	private Optional<Long> annotatedTimeout(TestExtensionContext context) {
+		return findAnnotation(context.getElement(), Test.class).map(Test::timeout).filter(timeout -> timeout != 0L);
+	}
+
+	private static void storeNowAsLaunchTime(ExtensionContext context) {
+		context.getStore(NAMESPACE).put(LAUNCH_TIME_KEY, currentTimeMillis());
+	}
+
+	private static long loadLaunchTime(ExtensionContext context) {
+		return context.getStore(NAMESPACE).get(LAUNCH_TIME_KEY, long.class);
+	}
+
+}

--- a/src/main/java/org/codefx/junit/io/vintage/TimeoutExtension.java
+++ b/src/main/java/org/codefx/junit/io/vintage/TimeoutExtension.java
@@ -22,6 +22,14 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.TestExtensionContext;
 
+/**
+ * This extension implements the timeout behavior of {@link Test @Test}, where a test is failed if it takes longer to finish
+ * than the specified time.
+ *
+ * <p>Note that this is different from JUnit 4's {@code @Test} parameter, which would abandon the test if it ran to
+ * long and continue with the remainder of the suite. As Jupiter's extension API is currently not powerful enough
+ * to interact with its threading model, this could not be implemented.
+ */
 class TimeoutExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
 
 	static final String TEST_RAN_TOO_LONG = "Test '%s' was supposed to run no longer than %d ms but ran %d ms.";

--- a/src/main/java/org/codefx/junit/io/vintage/package-info.java
+++ b/src/main/java/org/codefx/junit/io/vintage/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Contains extensions to JUnit Vintage, i.e. functionality that is concerned with older JUnit versions.
+ */
+
+package org.codefx.junit.io.vintage;

--- a/src/test/java/org/codefx/junit/io/AbstractIoTestEngineTests.java
+++ b/src/test/java/org/codefx/junit/io/AbstractIoTestEngineTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.codefx.junit.io;
+
+import static java.util.Arrays.stream;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
+import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.request;
+
+import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
+import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+
+public abstract class AbstractIoTestEngineTests extends AbstractJupiterTestEngineTests {
+
+	protected ExecutionEventRecorder executeTests(Class<?> type, String... methodNames) {
+		//@formatter:off
+		DiscoverySelector[] selectors = stream(methodNames)
+				.map(methodName -> selectMethod(type, methodName))
+				.toArray(DiscoverySelector[]::new);
+		LauncherDiscoveryRequest request = request().selectors(selectors).build();
+		//@formatter:on
+		return executeTests(request);
+	}
+
+}

--- a/src/test/java/org/codefx/junit/io/vintage/TestIntegrationTest.java
+++ b/src/test/java/org/codefx/junit/io/vintage/TestIntegrationTest.java
@@ -101,8 +101,7 @@ public class TestIntegrationTest extends AbstractIoTestEngineTests {
 
 	@org.junit.jupiter.api.Test
 	void testWithTimeout_belowTimeout_passes() {
-		ExecutionEventRecorder eventRecorder = executeTests(TestTestCase.class,
-				"testWithTimeout_belowTimeout");
+		ExecutionEventRecorder eventRecorder = executeTests(TestTestCase.class, "testWithTimeout_belowTimeout");
 
 		assertThat(eventRecorder.getTestStartedCount()).isEqualTo(1);
 		assertThat(eventRecorder.getTestSuccessfulCount()).isEqualTo(1);
@@ -110,8 +109,7 @@ public class TestIntegrationTest extends AbstractIoTestEngineTests {
 
 	@org.junit.jupiter.api.Test
 	void testWithTimeout_exceedsTimeout_fails() throws Exception {
-		ExecutionEventRecorder eventRecorder = executeTests(TestTestCase.class,
-				"testWithTimeout_exceedsTimeout");
+		ExecutionEventRecorder eventRecorder = executeTests(TestTestCase.class, "testWithTimeout_exceedsTimeout");
 
 		assertThat(eventRecorder.getTestStartedCount()).isEqualTo(1);
 		assertThat(eventRecorder.getTestFailedCount()).isEqualTo(1);

--- a/src/test/java/org/codefx/junit/io/vintage/TestIntegrationTest.java
+++ b/src/test/java/org/codefx/junit/io/vintage/TestIntegrationTest.java
@@ -10,10 +10,16 @@
 
 package org.codefx.junit.io.vintage;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.codefx.junit.io.vintage.ExpectedExceptionExtension.EXPECTED_EXCEPTION_WAS_NOT_THROWN;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.InvalidPathException;
+import java.util.Optional;
+
 import org.codefx.junit.io.AbstractIoTestEngineTests;
+import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 
 public class TestIntegrationTest extends AbstractIoTestEngineTests {
@@ -22,16 +28,70 @@ public class TestIntegrationTest extends AbstractIoTestEngineTests {
 	void test_successfulTest_passes() throws Exception {
 		ExecutionEventRecorder eventRecorder = executeTests(TestTestCase.class, "test_successfulTest");
 
-		assertEquals(1, eventRecorder.getTestStartedCount(), "# tests started");
-		assertEquals(1, eventRecorder.getTestSuccessfulCount(), "# tests succeeded");
+		assertThat(eventRecorder.getTestStartedCount()).isEqualTo(1);
+		assertThat(eventRecorder.getTestSuccessfulCount()).isEqualTo(1);
 	}
 
 	@org.junit.jupiter.api.Test
 	void test_exceptionThrown_fails() throws Exception {
 		ExecutionEventRecorder eventRecorder = executeTests(TestTestCase.class, "test_exceptionThrown");
 
-		assertEquals(1, eventRecorder.getTestStartedCount(), "# tests started");
-		assertEquals(1, eventRecorder.getTestFailedCount(), "# tests failed");
+		assertThat(eventRecorder.getTestStartedCount()).isEqualTo(1);
+		assertThat(eventRecorder.getTestFailedCount()).isEqualTo(1);
+	}
+
+	@org.junit.jupiter.api.Test
+	void testWithExpectedException_successfulTest_fails() {
+		ExecutionEventRecorder eventRecorder = executeTests(TestTestCase.class,
+			"testWithExpectedException_successfulTest");
+
+		assertThat(eventRecorder.getTestStartedCount()).isEqualTo(1);
+		assertThat(eventRecorder.getTestFailedCount()).isEqualTo(1);
+
+		//@formatter:off
+		Optional<String> failedTestMessage = eventRecorder
+				.getFailedTestFinishedEvents().get(0)
+				.getPayload(TestExecutionResult.class)
+				.flatMap(TestExecutionResult::getThrowable)
+				.map(Throwable::getMessage);
+		//@formatter:on
+		String expectedMessage = format(EXPECTED_EXCEPTION_WAS_NOT_THROWN, IllegalArgumentException.class);
+		assertThat(failedTestMessage).contains(expectedMessage);
+	}
+
+	@org.junit.jupiter.api.Test
+	void testWithExpectedException_exceptionThrownOfRightType_passes() {
+		ExecutionEventRecorder eventRecorder = executeTests(TestTestCase.class,
+			"testWithExpectedException_exceptionThrownOfRightType");
+
+		assertThat(eventRecorder.getTestStartedCount()).isEqualTo(1);
+		assertThat(eventRecorder.getTestSuccessfulCount()).isEqualTo(1);
+	}
+
+	@org.junit.jupiter.api.Test
+	void testWithExpectedException_exceptionThrownOfSubtype_passes() {
+		ExecutionEventRecorder eventRecorder = executeTests(TestTestCase.class,
+			"testWithExpectedException_exceptionThrownOfSubtype");
+
+		assertThat(eventRecorder.getTestStartedCount()).isEqualTo(1);
+		assertThat(eventRecorder.getTestSuccessfulCount()).isEqualTo(1);
+	}
+
+	@org.junit.jupiter.api.Test
+	void testWithExpectedException_exceptionThrownOfSupertype_fails() {
+		ExecutionEventRecorder eventRecorder = executeTests(TestTestCase.class,
+			"testWithExpectedException_exceptionThrownOfSupertype");
+
+		assertThat(eventRecorder.getTestStartedCount()).isEqualTo(1);
+		assertThat(eventRecorder.getTestFailedCount()).isEqualTo(1);
+
+		//@formatter:off
+		Optional<Throwable> failedTestThrowable = eventRecorder
+				.getFailedTestFinishedEvents().get(0)
+				.getPayload(TestExecutionResult.class)
+				.flatMap(TestExecutionResult::getThrowable);
+		//@formatter:on
+		assertThat(failedTestThrowable).containsInstanceOf(RuntimeException.class);
 	}
 
 	// TEST CASES -------------------------------------------------------------------
@@ -48,9 +108,24 @@ public class TestIntegrationTest extends AbstractIoTestEngineTests {
 			throw new IllegalArgumentException();
 		}
 
-		@Test
+		@Test(expected = IllegalArgumentException.class)
 		void testWithExpectedException_successfulTest() {
 			assertTrue(true);
+		}
+
+		@Test(expected = IllegalArgumentException.class)
+		void testWithExpectedException_exceptionThrownOfRightType() {
+			throw new IllegalArgumentException();
+		}
+
+		@Test(expected = IllegalArgumentException.class)
+		void testWithExpectedException_exceptionThrownOfSubtype() {
+			throw new InvalidPathException("", "");
+		}
+
+		@Test(expected = IllegalArgumentException.class)
+		void testWithExpectedException_exceptionThrownOfSupertype() {
+			throw new RuntimeException();
 		}
 
 	}

--- a/src/test/java/org/codefx/junit/io/vintage/TestIntegrationTest.java
+++ b/src/test/java/org/codefx/junit/io/vintage/TestIntegrationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.codefx.junit.io.vintage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.codefx.junit.io.AbstractIoTestEngineTests;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+
+public class TestIntegrationTest extends AbstractIoTestEngineTests {
+
+	@org.junit.jupiter.api.Test
+	void test_successfulTest_passes() throws Exception {
+		ExecutionEventRecorder eventRecorder = executeTests(TestTestCase.class, "test_successfulTest");
+
+		assertEquals(1, eventRecorder.getTestStartedCount(), "# tests started");
+		assertEquals(1, eventRecorder.getTestSuccessfulCount(), "# tests succeeded");
+	}
+
+	@org.junit.jupiter.api.Test
+	void test_exceptionThrown_fails() throws Exception {
+		ExecutionEventRecorder eventRecorder = executeTests(TestTestCase.class, "test_exceptionThrown");
+
+		assertEquals(1, eventRecorder.getTestStartedCount(), "# tests started");
+		assertEquals(1, eventRecorder.getTestFailedCount(), "# tests failed");
+	}
+
+	// TEST CASES -------------------------------------------------------------------
+
+	static class TestTestCase {
+
+		@Test
+		void test_successfulTest() {
+			assertTrue(true);
+		}
+
+		@Test
+		void test_exceptionThrown() {
+			throw new IllegalArgumentException();
+		}
+
+		@Test
+		void testWithExpectedException_successfulTest() {
+			assertTrue(true);
+		}
+
+	}
+
+}

--- a/src/test/java/org/codefx/junit/io/vintage/TestIntegrationTests.java
+++ b/src/test/java/org/codefx/junit/io/vintage/TestIntegrationTests.java
@@ -23,7 +23,10 @@ import org.codefx.junit.io.AbstractIoTestEngineTests;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 
-public class TestIntegrationTest extends AbstractIoTestEngineTests {
+/**
+ * Tests the vintage {@link Test @Test} annotation by running the entire test engine.
+ */
+class TestIntegrationTests extends AbstractIoTestEngineTests {
 
 	@org.junit.jupiter.api.Test
 	void test_successfulTest_passes() throws Exception {


### PR DESCRIPTION
Create an annotation `@Test` that has parameters `expected` and `timeout`. The former does what is expected (excuse the pun), the latter not exactly. Because Jupiter has no extension point to influence threading (yet?) the test can not actually be aborted if it runs too long. Instead, the test is failed when it ends and took too much time.

Fixes #7.

---

I hereby agree to the terms of the [Io Contributor License Agreement](../CONTRIBUTING.md#io-contributor-license-agreement).