### PR TITLE
Release Snapshot Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
 deploy:
   skip_cleanup: true
   provider: script
-  script: ./gradlew publish -p snapshot-repo-pass=$SNAPSHOT-REPO-PASS --stacktrace
+  script: ./gradlew publish -P snapshotRepoPass=$SNAPSHOT-REPO-PASS --stacktrace
   on:
     branch: master
     jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,11 @@ script:
   - java -version
   - ./gradlew -version
   - ./gradlew --refresh-dependencies clean check -Dscan
+
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: ./gradlew publish -p snapshot-repo-pass=$SNAPSHOT-REPO-PASS --stacktrace
+  on:
+    branch: master
+    jdk: oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,43 @@ publishing {
 
             artifact sourceJar
             artifact javadocJar
+
+            pom.withXml {
+                asNode().with {
+                    appendNode('packaging', 'jar')
+                    appendNode('name', 'JUnit Io')
+                    appendNode('description', 'JUnit 5 Extension Pack')
+                    appendNode('url', 'https://github.com/CodeFX-org/junit-io')
+                    appendNode('scm').with {
+                        appendNode('url', 'https://github.com/CodeFX-org/junit-io')
+                        appendNode('connection', 'scm:git:git://github.com:CodeFX-org/junit-io.git')
+                    }
+                    appendNode('issueManagement').with {
+                        appendNode('url', 'https://github.com/CodeFX-org/junit-io/issues')
+                        appendNode('system', 'GitHub')
+                    }
+                    appendNode('licenses').with {
+                        appendNode('license').with {
+                            appendNode('name', 'Eclipse Public License v1.0')
+                            appendNode('url', 'http://www.eclipse.org/legal/epl-v10.html')
+                        }
+                    }
+                    appendNode('organization').with {
+                        appendNode('name', 'CodeFX')
+                        appendNode('url', 'http://codefx.org')
+                    }
+                    appendNode('developers').with {
+                        appendNode('developer').with {
+                            appendNode('id', 'nipa')
+                            appendNode('name', 'Nicolai Parlog')
+                            appendNode('email', 'nipa@codefx.org')
+                            appendNode('organization', 'CodeFX')
+                            appendNode('organizationUrl', 'http://codefx.org')
+                            appendNode('timezone', '1')
+                        }
+                    }
+                }
+            }
         }
     }
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,13 @@ publishing {
         }
     }
     repositories {
-        mavenLocal()
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+            credentials {
+                username "nipa"
+                password project.getProperty('snapshot-repo-pass')
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,13 @@ publishing {
             artifact sourceJar
             artifact javadocJar
 
+            tasks.withType(Jar) {
+                from(project.projectDir) {
+                    include 'LICENSE.md'
+                    into 'META-INF'
+                }
+            }
+
             pom.withXml {
                 asNode().with {
                     appendNode('packaging', 'jar')

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,11 @@ apply plugin: 'maven-publish'
 
 sourceCompatibility = 1.8
 
+ext {
+    // the password needs to be specified via command line
+    snapshotRepoPass = project.hasProperty('snapshotRepoPass') ? project.getProperty('snapshotRepoPass') : ''
+}
+
 repositories {
     mavenCentral()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
@@ -127,7 +132,7 @@ publishing {
             url 'https://oss.sonatype.org/content/repositories/snapshots/'
             credentials {
                 username "nipa"
-                password project.getProperty('snapshot-repo-pass')
+                password project.snapshotRepoPass
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'java'
 apply plugin: 'com.diffplug.gradle.spotless'
 apply plugin: 'checkstyle'
 apply plugin: 'org.junit.platform.gradle.plugin'
+apply plugin: 'maven-publish'
 
 sourceCompatibility = 1.8
 
@@ -66,6 +67,30 @@ checkstyle {
     toolVersion = 6.11
     configFile = rootProject.file('.infra/checkstyle/checkstyle.xml')
     sourceSets = [ sourceSets.main ]
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+
+            artifact sourceJar
+            artifact javadocJar
+        }
+    }
+    repositories {
+        mavenLocal()
+    }
+}
+
+task sourceJar(type: Jar, dependsOn: classes) {
+    classifier 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
 }
 
 configure(rootProject) {


### PR DESCRIPTION
A first shot at configuring Travis to release snapshots into Sonatype's snapshot repo after each successful build on master. The publication itself works on the command line like so:

    gradle publish -P snapshot-repo-pass=...

---

I hereby agree to the terms of the [Io Contributor License Agreement](../CONTRIBUTING.md#io-contributor-license-agreement).