### PR TITLE
Create Javadoc during 'check' task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,14 @@ checkstyle {
     sourceSets = [ sourceSets.main ]
 }
 
+javadoc {
+    // of all the javadoc checks (accessibility, html, missing, reference, syntax; see
+    // https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#BEJEFABE)
+    // disable the warning for missing comments and tags because they spam the output
+    // (it does often not make sense to comment every tag; e.g. the @return tag on annotations)
+    options.addStringOption('Xdoclint:accessibility,html,syntax,reference', '-quiet')
+}
+
 // to find Javadoc errors early, let 'javadoc' task run during 'check'
 check.dependsOn javadoc
 // it should ran last, though

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,11 @@ checkstyle {
     sourceSets = [ sourceSets.main ]
 }
 
+// to find Javadoc errors early, let 'javadoc' task run during 'check'
+check.dependsOn javadoc
+// it should ran last, though
+javadoc.shouldRunAfter test
+
 publishing {
     publications {
         mavenJava(MavenPublication) {

--- a/src/main/java/org/codefx/junit/io/extension/package-info.java
+++ b/src/main/java/org/codefx/junit/io/extension/package-info.java
@@ -2,9 +2,9 @@
  * Extensions to the JUnit Jupiter engine.
  *
  * <p>Check out the following types for details:
- * <li>
- *     <ul>{@link org.codefx.junit.io.extension.DisabledOnOs} / {@link org.codefx.junit.io.extension.EnabledOnOs}</ul>
- * </li>
+ * <ul>
+ *     <li>{@link org.codefx.junit.io.extension.DisabledOnOs} / {@link org.codefx.junit.io.extension.EnabledOnOs}</li>
+ * </ul>
  */
 
 package org.codefx.junit.io.extension;


### PR DESCRIPTION
Create Javadoc during `gradle check` to make sure it runs successfully.

Fixes #20.

---

I hereby agree to the terms of the [Io Contributor License Agreement](../CONTRIBUTING.md#io-contributor-license-agreement).